### PR TITLE
feat(user): cria entidade User e mapeamento com TypeORM

### DIFF
--- a/rent-arise-backend/src/app.module.ts
+++ b/rent-arise-backend/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserModule } from './app/user/user.module';
 
 @Module({
   imports: [TypeOrmModule.forRoot({
@@ -7,7 +8,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
     database: ':memory:',
     entities: [__dirname + '/**/*.entity{.ts,.js}'],
     synchronize: true,
-  }),],
+  }), UserModule,],
   controllers: [],
   providers: [],
 })

--- a/rent-arise-backend/src/app/user/entity/user.entity.ts
+++ b/rent-arise-backend/src/app/user/entity/user.entity.ts
@@ -1,0 +1,29 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Role } from "../enums/role.enum";
+
+@Entity({name: 'usuarios'})
+export class UserEntity {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    fullname: string;
+
+    @Column({ unique: true })
+    username: string;
+
+    @Column({ unique: true })
+    email: string;
+
+    @Column()
+    password: string;
+
+    @Column({ unique: true })
+    cpf: string;
+
+    @CreateDateColumn({name: 'created_at'})
+    createdAt: string;
+
+    @Column({ type: 'text' })
+    role: Role;
+}

--- a/rent-arise-backend/src/app/user/enums/role.enum.ts
+++ b/rent-arise-backend/src/app/user/enums/role.enum.ts
@@ -1,0 +1,4 @@
+export enum Role {
+    ADMIN = 'admin',
+    USER = 'user',
+}

--- a/rent-arise-backend/src/app/user/user.controller.spec.ts
+++ b/rent-arise-backend/src/app/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/rent-arise-backend/src/app/user/user.controller.ts
+++ b/rent-arise-backend/src/app/user/user.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('api/user')
+export class UserController {}

--- a/rent-arise-backend/src/app/user/user.module.ts
+++ b/rent-arise-backend/src/app/user/user.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserEntity } from './entity/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserEntity])],
+  controllers: [UserController],
+  providers: [UserService],
+  exports: [UserService]
+})
+export class UserModule {}

--- a/rent-arise-backend/src/app/user/user.service.spec.ts
+++ b/rent-arise-backend/src/app/user/user.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/rent-arise-backend/src/app/user/user.service.ts
+++ b/rent-arise-backend/src/app/user/user.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UserService {}


### PR DESCRIPTION
### 📦 Pull Request: Criação da entidade `User`

**Tipo:** `feat`

---

### ✅ Descrição

Este PR adiciona a entidade `User` com mapeamento via **TypeORM**, representando a estrutura básica de usuários no sistema.

---

### 📁 Alterações incluídas

- Criação da classe `User` em `src/user/entity/user.entity.ts`
- Uso de decoradores `@Entity`, `@PrimaryGeneratedColumn`, `@Column`
- Mapeamento inicial com campos como: `id`, `nome`, `email`, `senha`, etc.