### PR TITLE
chore(docs): extrai anotações Swagger para arquivos externos em auth e user

### DIFF
--- a/rent-arise-backend/src/app/auth/auth.controller.ts
+++ b/rent-arise-backend/src/app/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags } from "@nestjs/swagger";
 import { AuthService } from "./auth.service";
 import { CreateUserDto } from "../user/dto/CreateUserDto";
 import { LoginDto } from "./dto/LoginDto";
+import { DocLogin, DocRegister } from "./docs/auth.docs";
 
 @Controller('api/auth')
 @ApiTags('auth')
@@ -10,11 +11,13 @@ export class AuthController {
     constructor(private readonly authService: AuthService) {}
 
     @Post('/register')
+    @DocRegister()
     async register(@Body() body: CreateUserDto){
         return await this.authService.signUp(body);
     }
 
     @Post('/login')
+    @DocLogin()
     async login(@Body() body: LoginDto){
         return await this.authService.signIn(body);
     }

--- a/rent-arise-backend/src/app/auth/docs/auth.docs.ts
+++ b/rent-arise-backend/src/app/auth/docs/auth.docs.ts
@@ -1,0 +1,19 @@
+import { applyDecorators } from "@nestjs/common/decorators/core/apply-decorators";
+import { ApiOperation } from "@nestjs/swagger/dist/decorators/api-operation.decorator";
+import { ApiResponse } from "@nestjs/swagger/dist/decorators/api-response.decorator";
+
+export function DocRegister() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Register a new user.' }),
+    ApiResponse({ status: 201, description: 'User successfully registered.' }),
+    ApiResponse({ status: 400, description: 'Validation failed.' })
+  );
+}
+
+export function DocLogin() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Authenticate user and return JWT token.' }),
+    ApiResponse({ status: 200, description: 'Login successful, token returned.' }),
+    ApiResponse({ status: 401, description: 'Invalid credentials.' })
+  );
+}

--- a/rent-arise-backend/src/app/user/docs/user.docs.ts
+++ b/rent-arise-backend/src/app/user/docs/user.docs.ts
@@ -1,0 +1,34 @@
+import { applyDecorators } from "@nestjs/common/decorators/core/apply-decorators";
+import { ApiOperation } from "@nestjs/swagger/dist/decorators/api-operation.decorator";
+import { ApiResponse } from "@nestjs/swagger/dist/decorators/api-response.decorator";
+
+export function DocGetAllUsers() {
+  return applyDecorators(
+    ApiOperation({ summary: 'List all users.' }),
+    ApiResponse({ status: 200, description: 'List of users' })
+  );
+}
+
+export function DocShowUser() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Returns user data.' }),
+    ApiResponse({ status: 200, description: 'User data successfully returned.' }),
+    ApiResponse({ status: 404, description: 'User not found.' })
+  );
+}
+
+export function DocUpdateUser() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update a user by id.' }),
+    ApiResponse({ status: 200, description: 'User updated successfully.' }),
+    ApiResponse({ status: 404, description: 'User not found.' })
+  );
+}
+
+export function DocDeleteUser() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Delete a user by id.' }),
+    ApiResponse({ status: 204, description: 'User removed successfully.' }),
+    ApiResponse({ status: 404, description: 'User not found.' })
+  );
+}

--- a/rent-arise-backend/src/app/user/user.controller.ts
+++ b/rent-arise-backend/src/app/user/user.controller.ts
@@ -6,6 +6,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Roles } from '../authorization/roles/roles.decorator';
 import { Role } from './enums/role.enum';
 import { RolesGuard } from '../authorization/roles/roles.guard';
+import { DocDeleteUser, DocGetAllUsers, DocShowUser, DocUpdateUser } from './docs/user.docs';
 
 @Controller('api/users')
 @ApiTags('users')
@@ -13,8 +14,7 @@ export class UserController {
     constructor(private readonly userService: UserService) {}
 
     @Get()
-    @ApiOperation({ summary: 'List all users.'})
-    @ApiResponse({ status: 200, description: 'List of users'})
+    @DocGetAllUsers()
     @UseGuards(JwtAuthGuard, RolesGuard)
     @Roles(Role.ADMIN)
     async index() {
@@ -22,28 +22,21 @@ export class UserController {
     }
 
     @Get(':id')
-    @ApiOperation({ summary: 'Returns user data.'})
-    @ApiResponse({ status: 200, description: 'User data successfully returned.'})
-    @ApiResponse({ status: 404, description: 'User not found.'})
+    @DocShowUser()
     @UseGuards(JwtAuthGuard)
     async show(@Param('id', new ParseUUIDPipe()) id: string){
         return await this.userService.findOne(id);
     }
 
     @Put(':id')
-    @ApiOperation({ summary: 'Updtate a user by id.'})
-    @ApiResponse({ status: 200, description: 'User updated successfully".'})
-    @ApiResponse({ status: 404, description: 'User not found.'})
+    @DocUpdateUser()
     @UseGuards(JwtAuthGuard)
     async update(@Param('id', new ParseUUIDPipe()) id: string, @Body() body: UpdateUserDto) {
         return await this.userService.update(id, body);
     }
 
     @Delete(':id')
-    @HttpCode(HttpStatus.NO_CONTENT)
-    @ApiOperation({ summary: 'Delete a user by id.'})
-    @ApiResponse({ status: 204, description: 'User removed successfully".'})
-    @ApiResponse({ status: 404, description: 'User not found.'})
+    @DocDeleteUser()
     @UseGuards(JwtAuthGuard)
     async destroy(@Param('id', new ParseUUIDPipe()) id: string) {
         await this.userService.deleteById(id);


### PR DESCRIPTION
### 📦 Pull Request: Separação da documentação Swagger dos controllers

**Tipo:** `chore`

---

### ✅ Descrição

Este PR realiza a separação das anotações de documentação Swagger dos controllers, movendo os decoradores como `@ApiOperation`, `@ApiResponse`, `@ApiTags`, etc., para arquivos externos específicos.

---

### 📁 Alterações incluídas

- Criação dos arquivos `auth.docs.ts` e `user.docs.ts` com funções decoradoras reutilizáveis
- Refatoração dos controllers `AuthController` e `UserController` para aplicar as anotações via funções externas
- Melhoria na organização do código e separação de responsabilidades

---

### 🎯 Objetivo

- Centralizar a documentação em arquivos próprios
- Manter os controllers mais limpos e focados exclusivamente na lógica de negócio
- Facilitar a manutenção e reuso das descrições de rotas

---

### 🧠 Observações

- A documentação continua sendo carregada normalmente pelo Swagger
- Não há impacto no funcionamento dos endpoints
- Essa abordagem pode ser replicada em outros módulos do projeto

---